### PR TITLE
Add downgrade info

### DIFF
--- a/lib/compare_linker/formatter/markdown.rb
+++ b/lib/compare_linker/formatter/markdown.rb
@@ -5,7 +5,8 @@ class CompareLinker
     class Markdown
       def format(gem_info)
         g = OpenStruct.new(gem_info)
-        case
+
+        text = case
         when g.owner
           "* #{g.gem_name}: https://github.com/#{g.owner}/#{g.gem_name}/compare/#{g.old_ver}...#{g.new_ver}"
         when g.homepage_uri
@@ -17,6 +18,12 @@ class CompareLinker
         else
           "* #{g.gem_name}: (link not found) #{g.old_ver} => #{g.new_ver}"
         end
+
+        if (g.old_tag && g.new_tag && g.new_tag.to_f < g.old_tag.to_f) || g.new_ver.to_f < g.old_ver.to_f
+          text += " (downgrade)"
+        end
+
+        text
       end
     end
   end

--- a/lib/compare_linker/formatter/text.rb
+++ b/lib/compare_linker/formatter/text.rb
@@ -5,7 +5,8 @@ class CompareLinker
     class Text
       def format(gem_info)
         g = OpenStruct.new(gem_info)
-        case
+
+        text = case
         when g.owner
           "#{g.gem_name}: https://github.com/#{g.owner}/#{g.gem_name}/compare/#{g.old_ver}...#{g.new_ver}"
         when g.homepage_uri
@@ -17,6 +18,12 @@ class CompareLinker
         else
           "#{g.gem_name} (link not found): #{g.old_ver} => #{g.new_ver}"
         end
+
+        if (g.old_tag && g.new_tag && g.new_tag.to_f < g.old_tag.to_f) || g.new_ver.to_f < g.old_ver.to_f
+          text += " (downgrade)"
+        end
+
+        text
       end
     end
   end


### PR DESCRIPTION
Today I've faced very weird behaviour such as

```
mail: mikel/mail@2.5.4...2.2.7
```

mail gem is downgraded unexpectedly.

As this super handy library, it's easy to find, and even more, if there's informaitive text might be useful.

```
mail: mikel/mail@2.5.4...2.2.7 (downgrade)
```

I'm really sorry about lack of test :bow: 
